### PR TITLE
Add option for HTTP method

### DIFF
--- a/src/GraphQL.elm
+++ b/src/GraphQL.elm
@@ -20,39 +20,73 @@ type alias ID =
 
 {-| Todo: document this function.
 -}
-query : String -> String -> String -> String -> Decoder a -> Task Http.Error a
-query url query operation variables decoder =
-    fetch "GET" url query operation variables decoder
+query : String -> String -> String -> String -> Json.Encode.Value -> Decoder a -> Task Http.Error a
+query method url query operation variables decoder =
+    fetch method url query operation variables decoder
 
 
 {-| Todo: document this function.
 -}
-mutation : String -> String -> String -> String -> Decoder a -> Task Http.Error a
+mutation : String -> String -> String -> Json.Encode.Value -> Decoder a -> Task Http.Error a
 mutation url query operation variables decoder =
     fetch "POST" url query operation variables decoder
 
 
 {-| Todo: document this function.
 -}
-fetch : String -> String -> String -> String -> String -> Decoder a -> Task Http.Error a
+fetch : String -> String -> String -> String -> Json.Encode.Value -> Decoder a -> Task Http.Error a
 fetch verb url query operation variables decoder =
     let
         request =
-            { verb = verb
-            , headers =
-                [ ( "Accept", "application/json" )
-                ]
-            , url =
-                (Http.url url
-                    [ ( "query", query )
-                    , ( "operationName", operation )
-                    , ( "variables", variables )
-                    ]
-                )
-            , body = Http.empty
-            }
+            (case verb of
+                "GET" ->
+                    buildRequestWithURLParams verb url query operation variables
+
+                _ ->
+                    buildRequestWithBody verb url query operation variables
+            )
     in
         Http.fromJson (queryResult decoder) (Http.send Http.defaultSettings request)
+
+
+{-| Todo: document this function.
+-}
+buildRequestWithURLParams : String -> String -> String -> String -> Json.Encode.Value -> Http.Request
+buildRequestWithURLParams verb url query operation variables =
+    let
+        params =
+            [ ( "query", query )
+            , ( "operationName", operation )
+            , ( "variables", (Json.Encode.encode 0 variables) )
+            ]
+    in
+        { verb = verb
+        , headers = [ ( "Accept", "application/json" ) ]
+        , url = Http.url url params
+        , body = Http.empty
+        }
+
+
+{-| Todo: document this function.
+-}
+buildRequestWithBody : String -> String -> String -> String -> Json.Encode.Value -> Http.Request
+buildRequestWithBody verb url query operation variables =
+    let
+        params =
+            Json.Encode.object
+                [ ( "query", Json.Encode.string query )
+                , ( "operationName", Json.Encode.string operation )
+                , ( "variables", variables )
+                ]
+    in
+        { verb = verb
+        , headers =
+            [ ( "Accept", "application/json" )
+            , ( "Content-Type", "application/json" )
+            ]
+        , url = Http.url url []
+        , body = Http.string <| Json.Encode.encode 0 params
+        }
 
 
 {-| Todo: document this function.

--- a/tool/package.json
+++ b/tool/package.json
@@ -12,6 +12,7 @@
   "license": "BSD",
   "private": true,
   "dependencies": {
+    "command-line-args": "^3.0.1",
     "graphql": "^0.4.14",
     "request": "^2.69.0",
     "source-map-support": "^0.4.0"

--- a/tool/src/query-to-elm.ts
+++ b/tool/src/query-to-elm.ts
@@ -9,11 +9,13 @@
 /// <reference path="../typings/graphql-types.d.ts" />
 /// <reference path="../typings/graphql-language.d.ts" />
 /// <reference path="../typings/graphql-utilities.d.ts" />
+/// <reference path="../typings/command-line-args.d.ts" />
 
 import 'source-map-support/register';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as request from 'request';
+import * as commandLineArgs from 'command-line-args';
 
 import {
   Definition,
@@ -68,17 +70,23 @@ import {
   decoderForFragment
 } from './query-to-decoder';
 
+let optionDefinitions = [
+  {name: "args", type: String, multiple: true, defaultOption: true}
+];
+
+let options = commandLineArgs(optionDefinitions);
+
 export type GraphQLEnumMap = { [name: string]: GraphQLEnumType };
 export type GraphQLTypeMap = { [name: string]: GraphQLType };
 export type FragmentDefinitionMap = { [name: string]: FragmentDefinition };
 
-let graphqlFile = process.argv[2];
+let graphqlFile = options["args"][0];
 if (!graphqlFile) {
   console.error('usage: query-to-elm graphql_file <introspection_endpoint_url> <live_endpoint_url>');
   process.exit(1);
 }
-let introspectionUrl = process.argv[3] || 'http://localhost:8080/graphql';
-let liveUrl = process.argv[4] || introspectionUrl;
+let introspectionUrl = options["args"][1] || 'http://localhost:8080/graphql';
+let liveUrl = options["args"][2] || introspectionUrl;
 
 let queries = fs.readFileSync(graphqlFile, 'utf8');
 let queryDocument = parse(queries);

--- a/tool/src/query-to-elm.ts
+++ b/tool/src/query-to-elm.ts
@@ -71,6 +71,7 @@ import {
 } from './query-to-decoder';
 
 let optionDefinitions = [
+  {name: "method", alias: "m", type: String},
   {name: "args", type: String, multiple: true, defaultOption: true}
 ];
 
@@ -98,8 +99,14 @@ let moduleName = 'GraphQL.' + filename;
 
 let outPath = path.join(path.dirname(graphqlFile), filename + '.elm');
 
-let url = introspectionUrl + '?query=' + encodeURIComponent(introspectionQuery.replace(/\n/g, '')); 
-request(url, function (err, res, body) {
+let url = introspectionUrl;
+let data = {query: introspectionQuery.replace(/\n/g, '')};
+let method = options["method"] || "GET";
+let reqopts = method == "GET" ? {url:url, method:method, qs:data}
+                              : {url:url, method:method,
+                                 headers: [{"Content-Type": "application/json"}],
+                                 body: JSON.stringify(data)};
+request(reqopts, function (err, res, body) {
   if (err) {
     throw new Error(err);
   } else if (res.statusCode == 200) {

--- a/tool/src/query-to-elm.ts
+++ b/tool/src/query-to-elm.ts
@@ -301,6 +301,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema): [Arr
       let elmParamsType = new ElmTypeRecord(parameters.map(p => new ElmFieldDecl(p.name, p.type)));
       let elmParams = new ElmParameterDecl('params', elmParamsType);
       let elmParamsDecl = elmParamsType.fields.length > 0 ? [elmParams] : [];
+      let methodParam = def.operation == 'query' ? `"${options['method'] || 'GET'}"` + ' ' : '';
 
       decls.push(new ElmFunctionDecl(
          funcName, elmParamsDecl, new ElmTypeName(`Task Http.Error ${resultType}`),
@@ -324,7 +325,7 @@ function translateQuery(uri: string, doc: Document, schema: GraphQLSchema): [Arr
              .join(`\n                , `) + '\n' +
              `                ]\n` +
              `    in\n` +
-             `    GraphQL.${def.operation} endpointUrl graphQLQuery "${name}" (encode 0 graphQLParams) ${decodeFuncName}`
+             `    GraphQL.${def.operation} ${methodParam}endpointUrl graphQLQuery "${name}" graphQLParams ${decodeFuncName}`
          }
       ));
       let resultTypeName = resultType[0].toUpperCase() + resultType.substr(1);

--- a/tool/typings/command-line-args.d.ts
+++ b/tool/typings/command-line-args.d.ts
@@ -1,0 +1,20 @@
+declare module "command-line-args" {
+  interface AnyMap {
+    [key: string]: any;
+  }
+
+  interface OptDef {
+    name: string;
+    alias?: string;
+    type: any;
+    multiple?: boolean;
+    defaultOption?: boolean;
+  }
+
+  interface CmdLineArgsAPI {
+    (optdefs: OptDef[], argv?: string[]) : AnyMap;
+  }
+
+  var api: CmdLineArgsAPI;
+  export = api;
+}


### PR DESCRIPTION
Hello

I'm writing an Elm application using [reindex.io](http://reindex.io) as the GraphQL backend and this package seems to be the only I found for GraphQL support. **Thanks a lot!**

The problem I found is that the GraphQL endpoint provided by Reindex does not respond to `GET` requests but expects to be queried through `POST` with an `application/json` payload.

I patched `elm-graphql` to allow the user to specify an HTTP method to use and apparently everything worked as expected; although I haven't tested the generated code yet.

The patch consists of three changes:
1. Add a command line parser to replace the current ad-hoc `process.argv` handling
2. Add a `--method` option where the user can pick POST instead of GET.
3. Adjust generated code and support library to use the method requested by the user

This PR contains all additions. But the first one has its own topic branch and I can create a new pull request if you only want 1.

Cheers!
