### PR TITLE
Compile typescript files after typescript is installed

### DIFF
--- a/tool/package.json
+++ b/tool/package.json
@@ -5,7 +5,7 @@
   "main": "lib/query-to-elm.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "preinstall": "tsc src/query-to-elm.ts --outDir lib --target ES5 --module commonjs --noImplicitAny --sourceMap",
+    "postinstall": "tsc src/query-to-elm.ts --outDir lib --target ES5 --module commonjs --noImplicitAny --sourceMap",
     "start": "node lib/query-to-elm.js"
   },
   "author": "John Hewson",


### PR DESCRIPTION
If you do not have typescript already installed, then the initial `npm install` fails. This fixes this issue by compiling the typescript files after typescipt is installed.
