### PR TITLE
Fix IntrospectionQuery when use non-GET methods

### DIFF
--- a/src/elm-ast.ts
+++ b/src/elm-ast.ts
@@ -129,7 +129,7 @@ export function typeToString(ty: ElmType, level: number, isField?: boolean): str
             ty.fields.map(f => fieldToString(f, level + 1)).join(`${indent}, `) +
             `${indent}}`;
   } else {
-    throw new Error('unexpected type: ' + ty.constructor.name + ' ' + JSON.stringify(ty));
+    console.error('unexpected type: ' +  JSON.stringify(ty)); 
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -86,12 +86,12 @@ let verb = config.method || 'GET';
 let endpointUrl = config.endpoint;
 
 performIntrospectionQuery(body => {
-  let result = JSON.parse(body);
+  let result = body;
   let schema = buildClientSchema(result.data);
   processFiles(schema);
 });
 
-function performIntrospectionQuery(callback: (body: string) => void) {
+function performIntrospectionQuery(callback: (body: any) => void) {
   // introspection query
   let introspectionUrl = config.schema || config.endpoint;
   if (!introspectionUrl) {
@@ -110,7 +110,8 @@ function performIntrospectionQuery(callback: (body: string) => void) {
     : { url: introspectionUrl,
         method,
         headers: [{ 'Content-Type': 'application/json' }],
-        body: JSON.stringify({ query: introspectionQuery })
+        json: true,
+        body: { query: introspectionQuery }
       };
 
   request(reqOpts, function (err, res, body) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -58,11 +58,11 @@ if (options.init) {
   config = elmPackageJson.graphql;
 
   if (options.schema) {
-    elmPackageJson.schema = options.schema;
+    elmPackageJson.graphql.schema = options.schema;
   }
 
   if (options.method) {
-    elmPackageJson.method = options.method;
+    elmPackageJson.graphql.method = options.method;
   }
 
   // check that the endpoint works


### PR DESCRIPTION
Hello,

I have try to use elm-graphql with Apollo Server that require to use only POST method and I found some problems and try to fix as below.

1) options.method and options.schema is not pass to the config object.
- add them to elmPackageJson.graphql instead elmPackageJson because the config object wull read from elmPackageJson.graphql.
  2) encode body with JSON.stringify is not work
- use the json: true option and set body object to body property directly.
  3) In my app there are some custon scalar types such as Date that will make unexpected type error
- log the error instead throw an error then a user will can fix elm code manually.

Thank you for your work.
